### PR TITLE
Update the version of ic2 to 2.8.220, fixes #12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ minecraft {
 }
 
 dependencies {
-	deobfCompile "net.industrial-craft:industrialcraft-2:2.8.111-ex112:dev"
+	deobfCompile "net.industrial-craft:industrialcraft-2:2.8.220-ex112:dev"
 	deobfCompile "com.mod-buildcraft:buildcraft-main:7.99.24.5"
 	//provided fileTree(dir: 'lib', include: '*.jar')
 }


### PR DESCRIPTION
Due to a change in the constructors of IC2's InvSlot classes (They now take an `IInventorySlotHolder` instead of a `TileEntityInventory`. No changes in the code are required because `TileEntityInventory` implements the said interface), the game crashes with a NoSuchMethodError (see the crash report in issue #12). This is fixed by updating the version if ic2 to 2.8.190+ and re-compiling the mod.